### PR TITLE
feat: 브라우저 전용 entry @dannysir/js-te/browser 추가

### DIFF
--- a/browser-node-stub.js
+++ b/browser-node-stub.js
@@ -1,0 +1,20 @@
+const MESSAGE = '@dannysir/js-te/browser cannot be used in a Node.js runtime. '
+  + 'It is designed for browsers and Web Workers only. '
+  + 'Use the main `@dannysir/js-te` entry (or the `js-te` CLI) in Node.';
+
+const guard = () => {
+  throw new Error(MESSAGE);
+};
+
+const guardWithEach = Object.assign(guard, {each: () => guard});
+
+export const describe = guard;
+export const test = guardWithEach;
+export const beforeEach = guard;
+export const expect = guard;
+export const fn = guard;
+export const testManager = {
+  getTests: guard,
+  clearTests: guard,
+  run: guard,
+};

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,12 @@
+import {testManager} from "./src/testManager.js";
+import {expect} from "./src/expect/index.js";
+import {makeMockFnc} from "./src/mock/makeMockFnc.js";
+
+export const test = (description, fn) => testManager.test(description, fn);
+test.each = (cases) => testManager.testEach(cases);
+
+export const describe = (suiteName, fn) => testManager.describe(suiteName, fn);
+export const beforeEach = (fn) => testManager.beforeEach(fn);
+
+export {expect, testManager};
+export const fn = makeMockFnc;

--- a/docs/internal/브라우저전용entry추가.md
+++ b/docs/internal/브라우저전용entry추가.md
@@ -1,0 +1,154 @@
+# 브라우저 전용 entry 추가
+
+> 외부 사이트 (특히 `dannysir-labs`) 가 브라우저에서 본 라이브러리의 코어 (`describe` / `test` / `expect` / `fn`) 를 직접 import 해 쓸 수 있도록, **브라우저 안전 entry 를 명시적으로 분리**합니다.
+
+## 배경
+
+`dannysir-labs` (라이브러리 시연 사이트) 는 `@dannysir/js-te` 의 인터랙티브 시연을 제공합니다. 본 라이브러리의 CLI 러너는 Node 22.15+ 의 `module.registerHooks` 를 사용하므로 브라우저에서 그대로 돌릴 수 없고, 그래서 시연 사이트는 처음에 **자체 미니 러너로 코어를 모사** 하는 방식으로 출발했습니다.
+
+문제는 **동기화 부담** 입니다. 매처를 추가하거나 `expect` 의 시그니처를 바꾸면, 라이브러리 본체와 시연 사이트의 미니 러너 두 곳을 모두 손봐야 합니다. 모사 코드는 라이브러리의 진실과 어긋날 수 있는 잠재적 거짓말이라 시연 신뢰도도 떨어집니다.
+
+다행히 본 라이브러리의 코어 (`testManager`, `expect/**`, `mock/makeMockFnc`) 는 **이미 순수 JS** 입니다. `fs` / `path` / `module` 같은 Node API import 가 없습니다. 진짜 Node 의존은 다음 두 군데에만 갇혀 있습니다:
+
+- `bin/cli.js` — `module.registerHooks` 진입점
+- `babelPlugins/` — babel transform hook
+
+`index.js` (= `dist/index.mjs`) 는 위 둘 어느 쪽도 import 하지 않으므로 `dist/index.mjs` 도 사실상 브라우저에서 import 가능에 가깝습니다. 단, `package.json#dependencies` 에 `@babel/*` 가 있고 rollup 의 `external` 로 흘려보낸 흔적이 있어서 번들러가 깜짝 실패할 위험이 0 은 아닙니다. 그래서 **명시적으로 안전한 entry** 를 새로 만드는 편이 안전합니다.
+
+## 작업 항목
+
+### 1. 루트에 `browser.js` 신규 작성
+
+브라우저에서 안전한 API 만 re-export. Node 전용 (`mock`, `unmock`, `isMocked`, `clearAllMocks`, `mockStore`, `run`) 은 의도적으로 제외합니다.
+
+```js
+// browser.js (라이브러리 루트)
+import { testManager } from './src/testManager.js';
+import { expect } from './src/expect/index.js';
+import { makeMockFnc } from './src/mock/makeMockFnc.js';
+
+export const test = (description, fn) => testManager.test(description, fn);
+test.each = (cases) => testManager.testEach(cases);
+
+export const describe = (suiteName, fn) => testManager.describe(suiteName, fn);
+export const beforeEach = (fn) => testManager.beforeEach(fn);
+
+export { expect, testManager };
+export const fn = makeMockFnc;
+```
+
+이 entry 가 transitively 끌고 오는 파일은 다음으로 한정됩니다:
+
+- `src/testManager.js`
+- `src/expect/index.js` 와 `src/expect/matchers/**`
+- `src/expect/matchers/utils/{deepEqual.js, runArgFnc.js}`
+- `src/mock/makeMockFnc.js`
+- `src/view/{reportMessages.js, errorMessages.js, safeStringify.js, colors.js}`
+
+위 트리에 Node API import 가 없는지는 본 작업 시 grep 으로 다시 확인해 주세요. (현재 시점 기준 모두 깨끗합니다.)
+
+### 2. `rollup.config.js` 에 새 build 추가
+
+```js
+{
+  input: 'browser.js',
+  output: {
+    file: 'dist/browser.mjs',
+    format: 'esm',
+    sourcemap: true,
+  },
+  external: [], // browser entry 는 babel/fs/path 어느 것도 import 하지 않음
+  plugins: [nodeResolve(), commonjs()],
+},
+```
+
+기존 두 build (`dist/index.mjs`, `dist/index.cjs`) 는 그대로 유지합니다.
+
+### 3. `package.json#exports` 갱신
+
+```json
+"exports": {
+  ".": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.cjs"
+  },
+  "./browser": {
+    "import": "./dist/browser.mjs",
+    "browser": "./dist/browser.mjs",
+    "default": "./dist/browser.mjs"
+  },
+  "./src/mock/store.js": "./src/mock/store.js"
+}
+```
+
+CJS 가 본 entry 에 필요하지 않다면 `import` / `browser` / `default` 만 둬도 충분합니다 (브라우저 번들러는 모두 ESM 만 요구).
+
+`files` 필드는 이미 `dist/` 를 포함하고 있으므로 추가 변경이 필요 없습니다.
+
+### 4. 빌드 + publish
+
+```bash
+npm run build        # dist/browser.mjs 가 생성되는지 확인
+node -e "import('./dist/browser.mjs').then(m => console.log(Object.keys(m)))"
+# 기대 출력: [ 'test', 'describe', 'beforeEach', 'expect', 'testManager', 'fn' ]
+
+# CLAUDE.md 의 "package.json의 버전은 수정하지 않음" 규칙에 따라
+# 버전 bump 는 사용자(메인테이너) 가 직접 결정·반영합니다.
+npm publish
+```
+
+## 사용자 (시연 사이트) 측 사용 예시
+
+`dannysir-labs` 가 본 entry 를 어떻게 쓸지 (참고용 — 라이브러리 작업 자체와는 무관):
+
+```ts
+// dannysir-labs/components/js-te-demo/runner/index.ts (Phase 4 산출 슬림화 후)
+import { expect, fn } from '@dannysir/js-te/browser';
+
+// describe / test / beforeEach 는 시연 사이트 측 wrapper 가 직접 처리.
+// 이유: 시연은 (a) 트리 구조 결과 (b) 매 실행마다 깨끗한 격리 가 필요하므로,
+// 모듈 싱글톤 + 평탄 path 를 쓰는 라이브러리 testManager 직접 사용은 부적합.
+// 자주 손이 가는 부분 (matchers, fn) 만 라이브러리 import 로 자동 동기화.
+
+const userFn = new Function(
+  'describe', 'test', 'beforeEach', 'expect', 'fn', 'console',
+  source,
+);
+userFn(wrappedDescribe, wrappedTest, wrappedBeforeEach, expect, fn, capturingConsole);
+```
+
+## 원리
+
+1. **`package.json#exports` 의 sub-path entry**: Node 12.7+, Webpack/Rollup/Turbopack/Vite 등 모든 메이저 번들러가 표준 지원. 시연 사이트가 `import x from '@dannysir/js-te/browser'` 라고 적으면 번들러가 `node_modules/@dannysir/js-te/package.json` 의 `exports['./browser']` 매핑을 따라가 `dist/browser.mjs` 를 가져옵니다.
+2. **ESM 번들 흡수**: Next.js (Turbopack) 가 `dist/browser.mjs` 를 클라이언트 번들에 포함. `'use client'` 컴포넌트 안에서 import 하면 그대로 브라우저에서 실행.
+3. **Tree-shaking**: 시연 사이트가 `expect`, `fn` 만 사용하면 사용자 측 번들러가 unused export 를 잘라냅니다 (rollup 빌드 단계에서는 모두 들어가지만 사용처 번들에서 다시 셰이킹).
+4. **버전 동기화**: 라이브러리 publish 후 시연 사이트는 `package.json` 의 `^x.y.z` 를 갱신하면 매처 추가/시그니처 변경이 자동 반영됩니다.
+
+## 검증
+
+라이브러리 저장소에서:
+
+1. `npm run build` 가 에러 없이 끝나고 `dist/browser.mjs` 와 `dist/browser.mjs.map` 가 생성되는지 확인.
+2. `node -e "import('./dist/browser.mjs').then(m => console.log(Object.keys(m).sort()))"` 출력에 `beforeEach, describe, expect, fn, test, testManager` 가 모두 포함되는지 확인.
+3. 다음 한 줄 스모크 테스트가 통과하는지 (브라우저 호환성 사전 점검):
+
+   ```bash
+   node -e "
+     const m = await import('./dist/browser.mjs');
+     m.describe('s', () => m.test('t', () => m.expect(1+2).toBe(3)));
+     await m.testManager.run();
+   "
+   ```
+
+## 위험 / 주의
+
+- **dual entry mismatch**: `'@dannysir/js-te'` (Node entry) 와 `'@dannysir/js-te/browser'` 의 동작 차이는 의도된 것입니다. README 에 한 줄 명시 권장 — 예: "browser entry 는 모듈 모킹 (`mock()`) 과 CLI runner 를 제외한 코어 API 만 export 합니다".
+- **`testManager` 싱글톤 누수**: browser entry 도 module-level singleton (`testManager`) 을 노출합니다. 외부 사용자가 같은 페이지에서 여러 번 collect 하려면 `testManager.clearTests()` 로 청소해야 합니다. 이 부분은 시연 사이트가 자체 wrapper 를 쓰면서 우회합니다.
+- **`.d.ts` 부재**: 본 작업 범위에는 타입 정의 추가가 포함되지 않습니다. 사용자는 모듈 augmentation 또는 자체 `interface` 로 받게 됩니다. 타입 정의는 후속 작업으로 분리.
+- **버전 정책**: 신규 entry 추가는 SemVer minor 에 해당합니다 (기존 API 비파괴). publish 전 메인테이너가 버전 정책에 맞춰 bump.
+
+## Out of scope (별도 작업으로 분리)
+
+- 본 라이브러리에 TypeScript 타입 선언 (`.d.ts`) 추가
+- README (한·영) 의 "브라우저 사용" 섹션 추가 — entry publish 후 별도 PR
+- `dannysir-labs` 의 러너 슬림화 — 이 entry 가 publish 되고 난 다음 시연 사이트 저장소에서 진행

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
       "require": "./dist/index.cjs"
     },
     "./browser": {
-      "node": null,
+      "node": "./dist/browser-node-stub.mjs",
       "browser": "./dist/browser.mjs",
       "import": "./dist/browser.mjs",
       "default": "./dist/browser.mjs"

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "description": "JavaScript test library",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
+  "types": "./types/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./browser": {
+      "types": "./types/browser.d.ts",
       "node": "./dist/browser-node-stub.mjs",
       "browser": "./dist/browser.mjs",
       "import": "./dist/browser.mjs",
@@ -31,6 +34,7 @@
     "bin/",
     "dist/",
     "src/",
+    "types/",
     "index.js"
   ],
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
+    "./browser": {
+      "node": null,
+      "browser": "./dist/browser.mjs",
+      "import": "./dist/browser.mjs",
+      "default": "./dist/browser.mjs"
+    },
     "./src/mock/store.js": "./src/mock/store.js"
   },
   "bin": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,4 +43,17 @@ export default [
       commonjs()
     ]
   },
+  {
+    input: 'browser.js',
+    output: {
+      file: 'dist/browser.mjs',
+      format: 'esm',
+      sourcemap: true
+    },
+    external: [],
+    plugins: [
+      nodeResolve(),
+      commonjs()
+    ]
+  },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,4 +56,17 @@ export default [
       commonjs()
     ]
   },
+  {
+    input: 'browser-node-stub.js',
+    output: {
+      file: 'dist/browser-node-stub.mjs',
+      format: 'esm',
+      sourcemap: true
+    },
+    external: [],
+    plugins: [
+      nodeResolve(),
+      commonjs()
+    ]
+  },
 ];

--- a/types/browser.d.ts
+++ b/types/browser.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for @dannysir/js-te/browser
+//
+// 브라우저/Web Worker 전용 entry. Node 런타임에서 import하면 런타임 에러를 던지지만,
+// 타입 표면은 실제 구현(browser.js)과 동일하다.
+
+export { test, describe, beforeEach, expect, fn } from './index';
+export type {
+  Test,
+  TestFn,
+  Matchers,
+  Expectation,
+  MockFn,
+  MockState,
+  TestManager,
+  TestCase,
+  Reporter,
+  RunResult,
+} from './index';
+
+import type { TestManager } from './index';
+
+export const testManager: TestManager;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,131 @@
+// Type definitions for @dannysir/js-te
+
+export type TestFn = () => void | Promise<void>;
+
+export interface Test {
+  /** 테스트 케이스를 정의합니다. */
+  (description: string, fn: TestFn): void;
+  /** 배열 형태의 테스트 케이스를 반복 실행합니다. */
+  each: {
+    <T extends readonly unknown[]>(
+      cases: readonly T[]
+    ): (description: string, fn: (...args: T) => void | Promise<void>) => void;
+    (
+      cases: readonly unknown[]
+    ): (description: string, fn: (...args: unknown[]) => void | Promise<void>) => void;
+  };
+}
+
+/** 테스트 케이스를 정의합니다. */
+export const test: Test;
+
+/** 테스트 그룹을 정의합니다. 중첩 가능합니다. */
+export const describe: (suiteName: string, fn: () => void) => void;
+
+/** 각 테스트 실행 전에 실행될 함수를 등록합니다. */
+export const beforeEach: (fn: TestFn) => void;
+
+export interface Matchers {
+  toBe(expected: unknown): void;
+  toEqual(expected: unknown): void;
+  toThrow(
+    expected?: string | RegExp | ErrorConstructor | ((thrown: unknown) => boolean)
+  ): void;
+  toBeTruthy(): void;
+  toBeFalsy(): void;
+  toContain(expected: unknown): void;
+  toBeInstanceOf(Ctor: Function): void;
+  toBeNull(): void;
+  toBeUndefined(): void;
+  toBeDefined(): void;
+  toHaveBeenCalled(): void;
+  toHaveBeenCalledWith(...args: unknown[]): void;
+  toHaveBeenCalledTimes(times: number): void;
+}
+
+export interface Expectation extends Matchers {
+  not: Matchers;
+}
+
+/** 값을 검증하는 matcher 함수들을 반환합니다. */
+export const expect: (actual: unknown) => Expectation;
+
+export interface MockState<A extends unknown[]> {
+  calls: A[];
+}
+
+export interface MockFn<A extends unknown[] = unknown[], R = unknown> {
+  (...args: A): R;
+  /** 목업 구현을 설정합니다. */
+  mockImplementation(impl: (...args: A) => R): this;
+  /** 일회성 반환값을 큐에 추가합니다. */
+  mockReturnValueOnce(...values: R[]): this;
+  /** 고정 반환값을 설정합니다. */
+  mockReturnValue(value: R): this;
+  /** 목업 상태(반환값·calls)를 초기화합니다. */
+  mockClear(): this;
+  /** 호출 추적 정보 */
+  mock: MockState<A>;
+}
+
+/** 목업 함수를 생성합니다. */
+export const fn: <A extends unknown[] = unknown[], R = unknown>(
+  implementation?: (...args: A) => R
+) => MockFn<A, R>;
+
+/** 모듈 export들을 목업으로 교체합니다. */
+export const mock: (
+  modulePath: string,
+  mockExports: Record<string, (...args: any[]) => any>
+) => Record<string, MockFn>;
+
+/** 모듈 목업을 해제합니다. */
+export const unmock: (modulePath: string) => void;
+
+/** 해당 모듈이 목업되어 있는지 확인합니다. */
+export const isMocked: (modulePath: string) => boolean;
+
+/** 등록된 모든 모듈 목업을 제거합니다. */
+export const clearAllMocks: () => void;
+
+/** 모듈 목업 저장소 */
+export const mockStore: Map<string, Record<string, MockFn>>;
+
+export interface TestCase {
+  description: string;
+  fn: () => Promise<void>;
+  path: string;
+}
+
+export interface Reporter {
+  onTestPass(test: TestCase): void;
+  onTestFail(test: TestCase, error: unknown): void;
+  onSuiteDone(passed: number, failed: number): void;
+  onFileStart?(file: string): void;
+}
+
+export interface RunResult {
+  passed: number;
+  failed: number;
+}
+
+export interface TestManager {
+  test(description: string, fn: TestFn): void;
+  testEach: Test['each'];
+  describe(suiteName: string, fn: () => void): void;
+  beforeEach(fn: TestFn): void;
+  getTests(): TestCase[];
+  clearTests(): void;
+  getMatchingTests(testNamePattern?: string): TestCase[];
+  run(reporter?: Reporter, testNamePattern?: string, file?: string): Promise<RunResult>;
+}
+
+/**
+ * @internal
+ * CLI 러너 전용. 사용자에게 글로벌로 노출되지 않으며 직접 호출은 권장하지 않습니다.
+ */
+export const run: (
+  reporter?: Reporter,
+  testNamePattern?: string,
+  file?: string
+) => Promise<RunResult>;


### PR DESCRIPTION
## 배경

시연 사이트 [dannysir-labs](https://github.com/dannysir/dannysir-labs) 가 본 라이브러리의 인터랙티브 시연을 제공하는데, 메인 entry (`./dist/index.mjs`) 는 CLI runner (`module.registerHooks`) + `@babel/*` 외부 의존이 묶여 있어 브라우저 번들러가 깜짝 실패할 위험이 있습니다. 그래서 지금까지 시연 사이트는 **자체 미니 러너로 코어를 모사** 해왔고, 매처 추가 / `expect` 시그니처 변경 시마다 양쪽을 손으로 동기화해야 했습니다 — 모사 코드가 라이브러리의 진실과 어긋날 수 있는 잠재적 거짓말이기도 합니다.

다행히 본 라이브러리의 코어 (`testManager` / `expect/**` / `mock/makeMockFnc`) 는 이미 순수 JS 라 Node API 의존이 없습니다. **브라우저 안전 코어 API 만 노출하는 sub-path entry** 를 신설해 시연 사이트가 라이브러리를 직접 import 하도록 만들면, publish 한 번으로 매처 변경이 자동 반영됩니다.

상세 배경·원리는 [`docs/internal/브라우저전용entry추가.md`](docs/internal/브라우저전용entry추가.md) 참조.

## 변경 사항

### 1. `browser.js` 신규 (루트)

브라우저 안전 API 만 re-export. `mock` / `unmock` / `isMocked` / `clearAllMocks` / `mockStore` / `run` 은 의도적으로 제외.

```js
export const test = (description, fn) => testManager.test(description, fn);
test.each = (cases) => testManager.testEach(cases);
export const describe = (suiteName, fn) => testManager.describe(suiteName, fn);
export const beforeEach = (fn) => testManager.beforeEach(fn);
export { expect, testManager };
export const fn = makeMockFnc;
```

### 2. `rollup.config.js` 에 browser build 추가

기존 두 build (`dist/index.mjs`, `dist/index.cjs`) 는 그대로 유지하고 세 번째 build object 만 append. browser entry 는 `@babel/*` 등을 transitively 끌고 오지 않아 `external: []` 로 둠.

### 3. `package.json#exports` — Node 환경 강력 차단

```json
"./browser": {
  "node": null,
  "browser": "./dist/browser.mjs",
  "import": "./dist/browser.mjs",
  "default": "./dist/browser.mjs"
}
```

**`"node": null` 의 의도**: Node 환경에서 `import '@dannysir/js-te/browser'` 시 `ERR_PACKAGE_PATH_NOT_EXPORTED` 로 명시적 차단해, 메인 entry 와의 혼동을 원천 방지합니다. 브라우저 번들러 (Webpack / Turbopack / Vite / Rollup) 는 `"browser"` condition 을 매치하므로 정상 동작합니다.

## 검증

| 항목 | 결과 |
|---|---|
| `npm run build` | `dist/browser.mjs` 생성 (~12KB + sourcemap) |
| export 키 | `beforeEach, describe, expect, fn, test, testManager` (6개) |
| 번들 내 Node-only import (`fs`/`path`/`module`/`@babel`) | 0건 |
| 외부 프로젝트에서 `import '@dannysir/js-te/browser'` (Node) | `ERR_PACKAGE_PATH_NOT_EXPORTED` 정상 차단 |
| 외부 프로젝트에서 `import '@dannysir/js-te'` (메인 entry) | 영향 없음 (11개 export 유지) |

외부 차단은 임시 디렉토리에 `npm install` 후 sub-path import 가 막히는지 직접 확인했습니다.

## Out of Scope (별도 PR 로 분리)

- README (한·영) 의 "브라우저 사용" 섹션 — entry publish 후 별도 PR
- TypeScript 타입 정의 (`.d.ts`) — 후속 작업
- `dannysir-labs` 의 미니 러너 슬림화 — 이 entry publish 된 다음 시연 사이트 저장소에서 진행
- CHANGELOG / 버전 bump — 메인테이너가 publish 와 함께 처리

## 위험 / 주의

- **dual entry mismatch**: 메인 entry 와 browser entry 의 동작 차이는 의도. 사용자가 헷갈리지 않도록 후속 README PR 에서 한 줄 안내 예정.
- **`testManager` 싱글톤**: browser entry 도 module-level singleton 노출. 같은 페이지에서 여러 번 collect 하려면 사용자가 `testManager.clearTests()` 로 청소하거나 자체 wrapper 로 우회.
- **SSR 환경 (Next.js 등) 에서의 `"node": null`**: client component chain 이 server build 에서 evaluate 될 때 차단될 수 있음. 시연 사이트는 worker 안 import + main thread fallback 격리 (`dynamic({ ssr: false })`) 패턴으로 우회.