### PR TITLE
fix: 브라우저 entry의 .only/.skip/.todo 모디파이어 누락 복구

### DIFF
--- a/browser-node-stub.js
+++ b/browser-node-stub.js
@@ -6,10 +6,16 @@ const guard = () => {
   throw new Error(MESSAGE);
 };
 
-const guardWithEach = Object.assign(guard, {each: () => guard});
+const testGuard = Object.assign(guard, {
+  each: () => guard,
+  only: guard,
+  skip: guard,
+  todo: guard,
+});
+const describeGuard = Object.assign(guard, {only: guard, skip: guard});
 
-export const describe = guard;
-export const test = guardWithEach;
+export const describe = describeGuard;
+export const test = testGuard;
 export const beforeEach = guard;
 export const expect = guard;
 export const fn = guard;

--- a/browser.js
+++ b/browser.js
@@ -4,8 +4,14 @@ import {makeMockFnc} from "./src/mock/makeMockFnc.js";
 
 export const test = (description, fn) => testManager.test(description, fn);
 test.each = (cases) => testManager.testEach(cases);
+test.only = (description, fn) => testManager.testOnly(description, fn);
+test.skip = (description, fn) => testManager.testSkip(description, fn);
+test.todo = (description) => testManager.testTodo(description);
 
 export const describe = (suiteName, fn) => testManager.describe(suiteName, fn);
+describe.only = (suiteName, fn) => testManager.describeOnly(suiteName, fn);
+describe.skip = (suiteName, fn) => testManager.describeSkip(suiteName, fn);
+
 export const beforeEach = (fn) => testManager.beforeEach(fn);
 
 export {expect, testManager};

--- a/docs/reference/API.ko.md
+++ b/docs/reference/API.ko.md
@@ -599,7 +599,7 @@ describe('math', () => {
 await testManager.run();
 ```
 
-**export 되는 것:** `test`(`test.each` 포함), `describe`, `beforeEach`, `expect`, `fn`, `testManager`.
+**export 되는 것:** `test`(`test.each`, `test.only`, `test.skip`, `test.todo` 포함), `describe`(`describe.only`, `describe.skip` 포함), `beforeEach`, `expect`, `fn`, `testManager`.
 
 **export 되지 않는 것:** 모듈 모킹(`mock`, `unmock`, `isMocked`, `clearAllMocks`, `mockStore`) 과 CLI 러너(`run`). Node 에 의존하므로 의도적으로 제외합니다 — 브라우저 entry 와 Node entry 의 표면 차이는 의도된 설계입니다.
 

--- a/docs/reference/API.ko.md
+++ b/docs/reference/API.ko.md
@@ -605,7 +605,7 @@ await testManager.run();
 
 `testManager` 는 모듈 레벨 싱글톤입니다. 같은 페이지에서 테스트를 여러 번 collect 한다면 실행 사이에 `testManager.clearTests()` 를 호출하세요.
 
-**Node 가드** — 이 entry 를 Node 런타임에서 import 하면 즉시 에러를 던지며, 메인 `@dannysir/js-te` entry(또는 `js-te` CLI) 로 안내합니다.
+**Node 가드** — 이 entry 를 Node 런타임에서 불러오면 가드 빌드로 연결되며, export 를 호출하는 순간 에러를 던져 메인 `@dannysir/js-te` entry(또는 `js-te` CLI) 로 안내합니다.
 
 **TypeScript** — 타입 선언이 패키지에 동봉되어(`types/browser.d.ts`) 별도 설정 없이 완전한 타입 지원을 받습니다.
 

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -599,7 +599,7 @@ describe('math', () => {
 await testManager.run();
 ```
 
-**Exported:** `test` (with `test.each`), `describe`, `beforeEach`, `expect`, `fn`, `testManager`.
+**Exported:** `test` (with `test.each`, `test.only`, `test.skip`, `test.todo`), `describe` (with `describe.only`, `describe.skip`), `beforeEach`, `expect`, `fn`, `testManager`.
 
 **Not exported:** module mocking (`mock`, `unmock`, `isMocked`, `clearAllMocks`, `mockStore`) and the CLI runner (`run`). These depend on Node and are intentionally left out — the browser and Node entries differ on purpose.
 

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -605,7 +605,7 @@ await testManager.run();
 
 `testManager` is a module-level singleton. If you collect tests more than once on the same page, call `testManager.clearTests()` between runs.
 
-**Node guard** — importing this entry from a Node runtime throws immediately, pointing you to the main `@dannysir/js-te` entry (or the `js-te` CLI).
+**Node guard** — in a Node runtime this entry resolves to a guard build; calling any of its exports throws, pointing you to the main `@dannysir/js-te` entry (or the `js-te` CLI).
 
 **TypeScript** — declarations ship with the package (`types/browser.d.ts`), so the entry is fully typed with no extra setup.
 


### PR DESCRIPTION
## 배경

`@dannysir/js-te/browser` 의 `test` / `describe` 가 `.only / .skip / .todo`
모디파이어를 **런타임에서 제공하지 않아**, 타입 선언과 실제 동작이 어긋나 있었습니다.

- `browser.js` 는 `6b1a801`(2026-05-19) 생성 이후 갱신되지 않았는데,
  `.only/.skip/.todo` 모디파이어는 0.9.0(`4f569d7`, 2026-06-03)에서
  **`index.js` 에만** 추가되었습니다.
- `types/browser.d.ts` 는 `test`/`describe` 를 `./index` 에서 그대로 re-export 하므로
  TS 사용자에게는 `test.only` 등이 보이지만, `dist/browser.mjs` 런타임에는 존재하지 않습니다.
- 결과적으로 브라우저에서 `test.only(...)` 호출 시 `TypeError: test.only is not a function`.

## 변경 사항

- **`browser.js`** — `test.only/.skip/.todo`, `describe.only/.skip` 위임 추가
  (`index.js` 와 동일하게 미러링).
- **`browser-node-stub.js`** — Node 가드에도 모디파이어를 부착. Node 에서 잘못 import 후
  `test.only(...)` 등을 호출해도 `TypeError` 대신 "use the main entry/CLI" 안내 에러를 던집니다.
- **`docs/reference/API.md` / `API.ko.md`**
  - 브라우저 entry "Exported:" 목록에 새 모디파이어 반영.
  - Node 가드 설명을 실제 동작에 맞게 정정(가드는 import 시점이 아니라
    export 를 **호출하는 순간** 에러를 던짐).

> `types/browser.d.ts` 는 이미 올바른 시그니처를 가리키므로 변경하지 않았습니다.
> 모킹 API(`mock/unmock/...`)가 브라우저에 없는 것은 설계 의도이며 이번 범위가 아닙니다.

## 커밋

- `fix:` 브라우저 entry에 `.only/.skip/.todo` 모디파이어 추가
- `docs:` 브라우저 Node 가드 설명을 실제 동작에 맞게 정정

## 검증

재빌드(`npm run build`) 후 `dist/browser.mjs` 기준:

1. **표면** — `test.each/only/skip/todo`, `describe.only/skip` 모두 `function` ✅
2. **동작** — `only` + `skip`×2 + `todo` 시나리오 → `{passed:1, failed:0, skipped:2, todo:1}`
   (only 로 인해 normal 1건이 skip 으로 강등) ✅
3. **Node 가드** — `dist/browser-node-stub.mjs` 의 `test.only/.skip/.todo`,
   `describe.skip` 호출 시 `TypeError` 가 아니라 안내 `Error` ✅
4. 기존 테스트 스위트(`npm test`) — `main` 과 동일(사전 존재하던 의도된 에러 데모 픽스처 2건 외 회귀 없음) ✅

> `dist/` 는 gitignore 대상이며 배포 시 `prepublishOnly`(=`npm run build`) 로 생성됩니다.
> 본 PR 의 변경 대상은 소스/문서 4개 파일입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)