### PR TITLE
feat: test.only.each / test.skip.each 모디파이어 조합 추가

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -1,5 +1,10 @@
 # CHANGE LOG
 
+## [Unreleased]
+
+### 추가
+- **`test.only.each` / `test.skip.each`** — modifier 와 데이터 기반(`.each`) 테스트의 조합. `test.only.each(cases)(template, fn)` 는 생성된 묶음 전체를 focus 하고(같은 파일의 다른 일반 테스트는 `skipped` 로 강등), `test.skip.each(cases)(template, fn)` 는 생성된 모든 케이스를 실행하지 않고 `skipped` 로 보고합니다. 메인 entry 와 `/browser` entry 양쪽에서 사용할 수 있습니다. 타입 선언은 `test.only` / `test.skip` 에 `each` 멤버를 추가했습니다.
+
 ## [0.9.2] 2026-06-13
 
 ### 수정

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 > Korean version: [CHANGELOG.ko.md](./CHANGELOG.ko.md)
 
+## [Unreleased]
+
+### Added
+- **`test.only.each` / `test.skip.each`** — modifier and data-driven (`.each`) combinations. `test.only.each(cases)(template, fn)` focuses an entire generated batch (other normal tests in the same file are demoted to `skipped`); `test.skip.each(cases)(template, fn)` reports every generated case as `skipped` without running it. Both are available from the main entry and the `/browser` entry. The type declarations extend `test.only` / `test.skip` with an `each` member.
+
 ## [0.9.2] 2026-06-13
 
 ### Fixed

--- a/README.ko.md
+++ b/README.ko.md
@@ -99,7 +99,7 @@ js-te --help          # 도움말
 
 ## 핵심 기능
 
-- **테스트 작성** — `test()`, `describe()`, `beforeEach()`, `test.each()`, `test.only`, `test.skip`, `test.todo`, `describe.only`, `describe.skip`
+- **테스트 작성** — `test()`, `describe()`, `beforeEach()`, `test.each()`, `test.only`, `test.skip`, `test.todo`, `test.only.each`, `test.skip.each`, `describe.only`, `describe.skip`
 - **Matcher** — `toBe`, `toEqual`, `toThrow`, `toBeTruthy`, `toBeFalsy`, `toContain`, `toBeInstanceOf`, `toBeNull`, `toBeUndefined`, `toBeDefined`, `toHaveBeenCalled`, `toHaveBeenCalledWith`, `toHaveBeenCalledTimes`, `.not` 체이닝
 - **Mock Function** — `fn()`, `mockImplementation`, `mockReturnValue`, `mockReturnValueOnce`, `mockClear`, `mock.calls`
 - **Module Mocking** — `mock(path, mockObj)` (상대/절대 경로 모두 지원), `clearAllMocks`, `unmock`, `isMocked`
@@ -198,7 +198,7 @@ describe('math', () => {
 await testManager.run();
 ```
 
-**export 되는 것:** `test`(`test.each` / `test.only` / `test.skip` / `test.todo` 포함), `describe`(`describe.only` / `describe.skip` 포함), `beforeEach`, `expect`, `fn`, `testManager`.
+**export 되는 것:** `test`(`test.each` / `test.only` / `test.skip` / `test.todo` / `test.only.each` / `test.skip.each` 포함), `describe`(`describe.only` / `describe.skip` 포함), `beforeEach`, `expect`, `fn`, `testManager`.
 
 **export 되지 않는 것:** 모듈 모킹(`mock`, `unmock`, `isMocked`, `clearAllMocks`, `mockStore`) 과 CLI 러너(`run`) — Node 전용이라 의도적으로 제외합니다.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See the [CLI reference](./docs/reference/CLI.md) for full options, matching rule
 
 ## Features
 
-- **Test writing** — `test()`, `describe()`, `beforeEach()`, `test.each()`, `test.only`, `test.skip`, `test.todo`, `describe.only`, `describe.skip`
+- **Test writing** — `test()`, `describe()`, `beforeEach()`, `test.each()`, `test.only`, `test.skip`, `test.todo`, `test.only.each`, `test.skip.each`, `describe.only`, `describe.skip`
 - **Matchers** — `toBe`, `toEqual`, `toThrow`, `toBeTruthy`, `toBeFalsy`, `toContain`, `toBeInstanceOf`, `toBeNull`, `toBeUndefined`, `toBeDefined`, `toHaveBeenCalled`, `toHaveBeenCalledWith`, `toHaveBeenCalledTimes`, `.not` chaining
 - **Mock Functions** — `fn()`, `mockImplementation`, `mockReturnValue`, `mockReturnValueOnce`, `mockClear`, `mock.calls`
 - **Module Mocking** — `mock(path, mockObj)` (relative & absolute paths), `clearAllMocks`, `unmock`, `isMocked`
@@ -199,7 +199,7 @@ describe('math', () => {
 await testManager.run();
 ```
 
-**Exported:** `test` (with `test.each`, `test.only`, `test.skip`, `test.todo`), `describe` (with `describe.only`, `describe.skip`), `beforeEach`, `expect`, `fn`, `testManager`.
+**Exported:** `test` (with `test.each`, `test.only`, `test.skip`, `test.todo`, `test.only.each`, `test.skip.each`), `describe` (with `describe.only`, `describe.skip`), `beforeEach`, `expect`, `fn`, `testManager`.
 
 **Not exported:** module mocking (`mock`, `unmock`, `isMocked`, `clearAllMocks`, `mockStore`) and the CLI runner (`run`) — these are Node-only and intentionally left out.
 

--- a/browser.js
+++ b/browser.js
@@ -5,7 +5,9 @@ import {makeMockFnc} from "./src/mock/makeMockFnc.js";
 export const test = (description, fn) => testManager.test(description, fn);
 test.each = (cases) => testManager.testEach(cases);
 test.only = (description, fn) => testManager.testOnly(description, fn);
+test.only.each = (cases) => testManager.testEach(cases, 'only');
 test.skip = (description, fn) => testManager.testSkip(description, fn);
+test.skip.each = (cases) => testManager.testEach(cases, 'skip');
 test.todo = (description) => testManager.testTodo(description);
 
 export const describe = (suiteName, fn) => testManager.describe(suiteName, fn);

--- a/docs/internal/backlog.md
+++ b/docs/internal/backlog.md
@@ -10,5 +10,5 @@
 - [x] **`describe` 그룹 단위 실행 (`--testLocation` 확장)** — IDE 어댑터(B) 로 종결. 라이브러리 측은 현 정확 일치 동작 유지하고, AST 로 범위를 풀어 하위 test 라인들로 라이브러리를 여러 번 호출하는 책임은 IDE 확장(별도 저장소) 이 맡음.
 - [x] **코드 레벨 `.only` / `.skip` / `.todo`** — `test.only` / `test.skip` / `test.todo`, `describe.only` / `describe.skip` 지원. `.only` 적용 범위는 파일 단위 (Jest 방식). reporter 인터페이스에 `onTestSkip` / `onTestTodo` 추가, `run()` 반환값에 `skipped` / `todo` 카운터 추가.
 - [x] **JSON reporter** — 테스트 결과를 콘솔 글자 대신 JSON 형태로 출력하는 기능. CI 스크립트나 IDE 확장이 결과를 쉽게 읽어 활용할 수 있게 함. 기존 콘솔 reporter 옆에 `jsonReporter` 를 추가하는 형태.
-- [ ] **`test.each` 와 modifier 조합** — `test.only.each(...)`, `test.skip.each(...)`, `test.each(...).only` 등. 현재 1차 범위에서 제외. Jest/Vitest 양쪽 다 지원하므로 후속에서 통일.
+- [x] **`test.each` 와 modifier 조합** — `test.only.each(...)` / `test.skip.each(...)` 추가. `testEach(cases, mode)` 로 모드 전달, 양쪽 entry(index/browser) + 타입(`only`/`skip` 에 `each` 멤버) 반영. `test.each(...).only` 체이닝은 Jest/Vitest 표준이 아니라 제외, `describe.only.each` / `describe.skip.each` 는 `describe.each` 가 선결이라 범위 밖.
 - [ ] VSCode / IDEA 확장 (별도 저장소, 위 라인 기반 실행이 선결)

--- a/docs/reference/API.ko.md
+++ b/docs/reference/API.ko.md
@@ -172,6 +172,19 @@ describe('user', () => {
 
 `test.only` 와 `describe` modifier 가 충돌하면 **가장 가까운 명시 modifier 가 우선**합니다. `describe.only` 안의 `test.skip` 은 그대로 skip, `describe.skip` 안의 `test.only` 는 그대로 실행됩니다.
 
+#### `.each` 와 조합
+
+`test.only.each(cases)(template, fn)` 와 `test.skip.each(cases)(template, fn)` 는 생성되는 모든 케이스에 modifier 를 적용합니다. `only` 는 묶음 전체를 focus 하고(같은 파일의 다른 일반 테스트는 `skipped` 로 강등), `skip` 은 모든 케이스를 실행하지 않고 `skipped` 로 보고합니다.
+
+```js
+test.skip.each([
+  [1, 2, 3],
+  [2, 3, 5],
+])('add(%s, %s) = %s — 임시 skip', (a, b, expected) => {
+  expect(a + b).toBe(expected);
+});
+```
+
 ### `describe.only(name, fn)` / `describe.skip(name, fn)`
 
 그룹 단위 focus·skip.

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -172,6 +172,19 @@ describe('user', () => {
 
 When `test.only` and a `describe` modifier disagree, the **closest explicit modifier wins**: `test.skip` inside `describe.only` stays skipped; `test.only` inside `describe.skip` still runs.
 
+#### Combining with `.each`
+
+`test.only.each(cases)(template, fn)` and `test.skip.each(cases)(template, fn)` apply the modifier to every generated case. `only` focuses the whole batch (and demotes other normal tests in the file to `skipped`); `skip` reports every case as `skipped` without running it.
+
+```js
+test.skip.each([
+  [1, 2, 3],
+  [2, 3, 5],
+])('add(%s, %s) = %s — temporarily skipped', (a, b, expected) => {
+  expect(a + b).toBe(expected);
+});
+```
+
 ### `describe.only(name, fn)` / `describe.skip(name, fn)`
 
 Group-level focus and skip.

--- a/index.js
+++ b/index.js
@@ -40,12 +40,38 @@ test.each = (cases) => testManager.testEach(cases);
 test.only = (description, fn) => testManager.testOnly(description, fn);
 
 /**
+ * 데이터 기반 테스트 묶음 전체를 only 로 등록합니다. 같은 파일의 일반 테스트는 skip 으로 강등됩니다.
+ *
+ * @example
+ * test.only.each([
+ *   [1, 2, 3],
+ *   [2, 3, 5],
+ * ])('add(%s, %s) = %s', (a, b, expected) => {
+ *   expect(a + b).toBe(expected);
+ * });
+ */
+test.only.each = (cases) => testManager.testEach(cases, 'only');
+
+/**
  * 테스트를 실행하지 않고 skipped 로 보고합니다.
  *
  * @example
  * test.skip('temporarily disabled', () => { ... });
  */
 test.skip = (description, fn) => testManager.testSkip(description, fn);
+
+/**
+ * 데이터 기반 테스트 묶음 전체를 skip 으로 등록합니다. 함수는 실행되지 않습니다.
+ *
+ * @example
+ * test.skip.each([
+ *   [1, 2, 3],
+ *   [2, 3, 5],
+ * ])('add(%s, %s) = %s', (a, b, expected) => {
+ *   expect(a + b).toBe(expected);
+ * });
+ */
+test.skip.each = (cases) => testManager.testEach(cases, 'skip');
 
 /**
  * 아직 구현되지 않은 테스트를 todo 로 보고합니다. 함수 인자를 받지 않습니다.

--- a/src/testManager.js
+++ b/src/testManager.js
@@ -100,11 +100,11 @@ class TestManager {
     this.#registerTest(description, () => {}, 'todo');
   }
 
-  testEach(cases) {
+  testEach(cases, mode) {
     return (description, fn) => {
       cases.forEach(testCase => {
         const args = Array.isArray(testCase) ? testCase : [testCase];
-        this.test(this.#formatDescription(args, description), () => fn(...args));
+        this.#registerTest(this.#formatDescription(args, description), () => fn(...args), mode);
       });
     };
   }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -102,6 +102,14 @@ test.each([
   expect(arg.name).toBe('dannysir');
 });
 
+// skip.each 의 케이스는 실행되지 않으므로, 일부러 실패할 단언을 넣어 skip 동작을 검증한다.
+test.skip.each([
+  [1, 2],
+  [3, 4],
+])('[skip.each] - skipped : %s, %s', (a, b) => {
+  expect(a).toBe(b);
+});
+
 describe('[beforeEach test]', () => {
   let counter;
   beforeEach(() => {

--- a/test/testManagerModes.test.js
+++ b/test/testManagerModes.test.js
@@ -133,3 +133,42 @@ describe('[TestManager modes] describe.only / describe.skip', () => {
     expect(result.skipped).toBe(1);
   });
 });
+
+describe('[TestManager modes] testEach + modifier', () => {
+  test('testEach(cases, "only") 는 케이스 전체를 only 로 등록하고 같은 파일 normal 은 skip 강등된다', async () => {
+    const tm = new TestManager();
+    tm.test('normal outside', () => {});
+    tm.testEach([[1, 1], [2, 2]], 'only')('case %s == %s', (a, b) => {
+      expect(a).toBe(b);
+    });
+
+    const result = await tm.run(makeReporter());
+
+    expect(result.passed).toBe(2);
+    expect(result.skipped).toBe(1);
+  });
+
+  test('testEach(cases, "skip") 는 케이스 함수를 실행하지 않고 skip 으로 보고한다', async () => {
+    const tm = new TestManager();
+    let runs = 0;
+    tm.testEach([[1], [2], [3]], 'skip')('case %s', () => { runs++; });
+
+    const reporter = makeReporter();
+    const result = await tm.run(reporter);
+
+    expect(runs).toBe(0);
+    expect(result.skipped).toBe(3);
+    expect(reporter.skipped.length).toBe(3);
+  });
+
+  test('testEach(cases) 는 mode 없이 normal 로 등록된다 (회귀 방지)', async () => {
+    const tm = new TestManager();
+    tm.testEach([[1, 1], [2, 2]])('case %s == %s', (a, b) => {
+      expect(a).toBe(b);
+    });
+
+    const result = await tm.run(makeReporter());
+
+    expect(result).toEqual({passed: 2, failed: 0, skipped: 0, todo: 0});
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,9 +17,17 @@ export interface Test {
     ): (description: string, fn: (...args: unknown[]) => void | Promise<void>) => void;
   };
   /** 같은 파일의 일반 테스트를 모두 skip 처리하고 이 테스트만 실행합니다. */
-  only: (description: string, fn: TestFn) => void;
+  only: {
+    (description: string, fn: TestFn): void;
+    /** 데이터 기반 테스트 묶음 전체를 only 로 등록합니다. */
+    each: Test['each'];
+  };
   /** 테스트를 실행하지 않고 skipped 로 보고합니다. */
-  skip: (description: string, fn: TestFn) => void;
+  skip: {
+    (description: string, fn: TestFn): void;
+    /** 데이터 기반 테스트 묶음 전체를 skip 으로 등록합니다. */
+    each: Test['each'];
+  };
   /** 아직 구현되지 않은 테스트를 todo 로 보고합니다. 함수 인자를 받지 않습니다. */
   todo: (description: string) => void;
 }


### PR DESCRIPTION
## 배경
`docs/internal/backlog.md`의 마지막 미완료 기능 항목입니다. `test.each` / `test.only` /
`test.skip`이 각각 존재했지만 조합(`test.only.each`, `test.skip.each`)이 불가능했습니다.
Jest/Vitest 양쪽이 지원하는 표준 조합이라 라이브러리 단독으로 마무리합니다.

## 변경 내용
- **런타임** (`src/testManager.js`): `testEach(cases)` → `testEach(cases, mode)`.
  내부를 `this.test(...)`에서 `#registerTest(..., mode)`로 교체. mode 미지정 시 기존 동작
  그대로(`test.each` 회귀 없음), `'only'`/`'skip'`이면 케이스 전체를 해당 모드로 등록.
- **진입점** (`index.js`, `browser.js`): 양쪽 entry에 `test.only.each` / `test.skip.each` 노출.
  (0.9.2의 browser entry 동기화 누락 교훈 반영해 두 entry를 함께 수정)
- **타입** (`types/index.d.ts`): `Test`의 `only`/`skip`을 호출 가능 + `.each` 보유 형태로 확장.
  `types/browser.d.ts`는 `Test`를 re-export하므로 자동 반영.
- **테스트**: TestManager 단위 테스트 3개(only 강등 / skip 미실행 / mode 없을 때 normal 회귀 방지)
  + `basic.test.js`에 `skip.each` 스모크(일부러 실패할 단언을 넣어 skip 회귀를 즉시 잡도록).
- **문서**: README·API 레퍼런스·CHANGELOG(en/ko) + backlog 체크.

## 검증
- 신규 단위 테스트 3개 통과. `only.each`는 임시 probe 파일로 파일 단위 only 강등까지 확인 후 정리.
- 전체: `176 passed, 2 failed, 2 skipped` — 2 failed는 기존 `error.test.js`의 의도적 실패
  리포팅 픽스처(이번 변경과 무관), 2 skipped는 추가한 `skip.each` 케이스(정상 동작).
- `package.json` 버전 미수정. `dist/`는 git 미추적(publish 시 빌드).

## 커밋 구성
1. `feat: test.only.each / test.skip.each 모디파이어 조합 추가` — 런타임·진입점·타입
2. `test: testEach 모디파이어 조합 단위 테스트 추가`
3. `docs: test.only.each / test.skip.each 문서화 + backlog 체크`

🤖 Generated with [Claude Code](https://claude.com/claude-code)